### PR TITLE
Accept richer text from remote posts

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -49,6 +49,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_hide_network,
       :setting_aggregate_reblogs,
       :setting_show_application,
+      :setting_strip_formatting,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -122,6 +122,17 @@ module StreamEntriesHelper
     end
   end
 
+  def text_formatting_classes
+    case current_user&.setting_strip_formatting
+    when 'none', nil
+      'rich-text rich-blocks'
+    when 'blocks'
+      'rich-text'
+    when 'all'
+      nil
+    end
+  end
+
   def style_classes(status, is_predecessor, is_successor, include_threads)
     classes = ['entry']
     classes << 'entry-predecessor' if is_predecessor

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -6,6 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import Permalink from './permalink';
 import classnames from 'classnames';
 import Icon from 'mastodon/components/icon';
+import { stripFormatting } from 'mastodon/initial_state';
 
 const MAX_HEIGHT = 642; // 20px * 32 (+ 2px padding at the top)
 
@@ -153,6 +154,8 @@ export default class StatusContent extends React.PureComponent {
       'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
       'status__content--collapsed': this.state.collapsed === true,
+      'rich-text': stripFormatting !== 'all',
+      'rich-blocks': stripFormatting === 'none',
     });
 
     if (isRtl(status.get('search_index'))) {
@@ -217,7 +220,7 @@ export default class StatusContent extends React.PureComponent {
         <div
           tabIndex='0'
           ref={this.setRef}
-          className='status__content'
+          className={classNames}
           style={directionStyle}
           dangerouslySetInnerHTML={content}
         />

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -18,5 +18,6 @@ export const version = getMeta('version');
 export const mascot = getMeta('mascot');
 export const profile_directory = getMeta('profile_directory');
 export const isStaff = getMeta('is_staff');
+export const stripFormatting = getMeta('strip_formatting');
 
 export default initialState;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -671,30 +671,10 @@
   h3,
   h4,
   h5 {
-    margin-top: 20px;
     margin-bottom: 20px;
   }
 
-  h1,
-  h2 {
-    font-weight: 700;
-    font-size: 18px;
-  }
-
-  h2 {
-    font-size: 16px;
-  }
-
-  h3,
-  h4,
-  h5 {
-    font-weight: 500;
-  }
-
   blockquote {
-    padding-left: 10px;
-    border-left: 3px solid $darker-text-color;
-    color: $darker-text-color;
     white-space: normal;
 
     p:last-child {
@@ -702,31 +682,70 @@
     }
   }
 
-  b,
-  strong {
-    font-weight: 700;
-  }
-
-  em,
-  i {
-    font-style: italic;
-  }
-
   ul,
   ol {
-    margin-left: 1em;
-
     p {
-      margin: 0;
+      margin-bottom: 0;
     }
   }
 
-  ul {
-    list-style-type: disc;
+  &:not(.rich-text) {
+    del {
+      text-decoration: none;
+    }
   }
 
-  ol {
-    list-style-type: decimal;
+  &.rich-text {
+    h1,
+    h2 {
+      font-weight: 700;
+    }
+
+    h3,
+    h4,
+    h5 {
+      font-weight: 500;
+    }
+
+    b,
+    strong {
+      font-weight: 700;
+    }
+
+    em,
+    i {
+      font-style: italic;
+    }
+  }
+
+  &.rich-blocks {
+    h1,
+    h2 {
+      font-size: 18px;
+    }
+
+    h2 {
+      font-size: 16px;
+    }
+
+    blockquote {
+      padding-left: 10px;
+      border-left: 3px solid $darker-text-color;
+      color: $darker-text-color;
+    }
+
+    ul,
+    ol {
+      margin-left: 1em;
+    }
+
+    ul {
+      list-style-type: disc;
+    }
+
+    ol {
+      list-style-type: decimal;
+    }
   }
 
   a {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -693,6 +693,10 @@
     del {
       text-decoration: none;
     }
+
+    code {
+      font-family: inherit;
+    }
   }
 
   &.rich-text {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -698,6 +698,10 @@
       font-family: inherit;
     }
 
+    u {
+      text-decoration: none;
+    }
+
     h1::before {
       content: '# ';
     }
@@ -767,6 +771,11 @@
     em,
     i {
       font-style: italic;
+    }
+
+    sub {
+      font-size: smaller;
+      text-align: sub;
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -677,7 +677,7 @@
 
   h1,
   h2 {
-    font-weight: 500;
+    font-weight: 700;
     font-size: 18px;
   }
 
@@ -685,14 +685,26 @@
     font-size: 16px;
   }
 
+  h3,
+  h4,
+  h5 {
+    font-weight: 500;
+  }
+
   blockquote {
-    margin-left: 20px;
-    color: $dark-text-color;
+    padding-left: 10px;
+    border-left: 3px solid $darker-text-color;
+    color: $darker-text-color;
+    white-space: normal;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 
   b,
   strong {
-    font-weight: 500;
+    font-weight: 700;
   }
 
   em,
@@ -703,6 +715,10 @@
   ul,
   ol {
     margin-left: 1em;
+
+    p {
+      margin: 0;
+    }
   }
 
   ul {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -697,6 +697,54 @@
     code {
       font-family: inherit;
     }
+
+    h1::before {
+      content: '# ';
+    }
+
+    h2::before {
+      content: '## ';
+    }
+
+    h3::before {
+      content: '### ';
+    }
+
+    h4::before {
+      content: '#### ';
+    }
+
+    h5::before {
+      content: '##### ';
+    }
+  }
+
+  &:not(.rich-blocks) {
+    blockquote {
+      position: relative;
+      padding-left: 1em;
+      overflow: hidden;
+    }
+
+    blockquote::before {
+      position: absolute;
+      content: '>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a';
+      white-space: pre-wrap;
+      left: 0;
+      top: 0;
+    }
+
+    li::before {
+      position: absolute;
+      content: '*';
+      left: 0;
+      top: 0;
+    }
+
+    li {
+      position: relative;
+      padding-left: 1em;
+    }
   }
 
   &.rich-text {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -692,6 +692,11 @@
   &:not(.rich-text) {
     del {
       text-decoration: none;
+
+      &::before,
+      &::after {
+        content: '~~';
+      }
     }
 
     code {
@@ -700,6 +705,11 @@
 
     u {
       text-decoration: none;
+
+      &::before,
+      &::after {
+        content: '__';
+      }
     }
 
     h1::before {
@@ -720,6 +730,22 @@
 
     h5::before {
       content: '##### ';
+    }
+
+    b,
+    strong {
+      &::before,
+      &::after {
+        content: '**';
+      }
+    }
+
+    em,
+    i {
+      &::before,
+      &::after {
+        content: '*';
+      }
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -647,10 +647,6 @@
 
   &.status__content--with-spoiler {
     white-space: normal;
-
-    .status__content__text {
-      white-space: pre-wrap;
-    }
   }
 
   .emojione {
@@ -659,13 +655,62 @@
     margin: -3px 0 0;
   }
 
-  p {
+  p,
+  pre,
+  blockquote {
     margin-bottom: 20px;
     white-space: pre-wrap;
 
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  h1,
+  h2 {
+    font-weight: 500;
+    font-size: 18px;
+  }
+
+  h2 {
+    font-size: 16px;
+  }
+
+  blockquote {
+    margin-left: 20px;
+    color: $dark-text-color;
+  }
+
+  b,
+  strong {
+    font-weight: 500;
+  }
+
+  em,
+  i {
+    font-style: italic;
+  }
+
+  ul,
+  ol {
+    margin-left: 1em;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-type: decimal;
   }
 
   a {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,7 +20,7 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a abbr del pre blockquote code b strong i em h1 h2 h3 h4 h5 ul ol li),
+      elements: %w(p br span a abbr del pre blockquote code b strong u sub i em h1 h2 h3 h4 h5 ul ol li),
 
       attributes: {
         'a'          => %w(href rel class title),

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,11 +20,13 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a),
+      elements: %w(p br span a abbr del pre blockquote code b strong i em h1 h2 h3 h4 h5 ul ol li),
 
       attributes: {
-        'a'    => %w(href rel class),
-        'span' => %w(class),
+        'a'          => %w(href rel class title),
+        'span'       => %w(class),
+        'abbr'       => %w(title),
+        'blockquote' => %w(cite),
       },
 
       add_attributes: {
@@ -35,7 +37,8 @@ class Sanitize
       },
 
       protocols: {
-        'a' => { 'href' => HTTP_PROTOCOLS },
+        'a'          => { 'href' => HTTP_PROTOCOLS },
+        'blockquote' => { 'cite' => HTTP_PROTOCOLS },
       },
 
       transformers: [

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -33,6 +33,7 @@ class UserSettingsDecorator
     user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
     user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
     user.settings['show_application']    = show_application_preference if change?('setting_show_application')
+    user.settings['strip_formatting']    = strip_formatting_preference if change?('setting_strip_formatting')
   end
 
   def merged_notification_emails
@@ -105,6 +106,10 @@ class UserSettingsDecorator
 
   def aggregate_reblogs_preference
     boolean_cast_setting 'setting_aggregate_reblogs'
+  end
+
+  def strip_formatting_preference
+    settings['setting_strip_formatting']
   end
 
   def boolean_cast_setting(key)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,8 @@ class User < ApplicationRecord
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
-           :expand_spoilers, :default_language, :aggregate_reblogs, :show_application, to: :settings, prefix: :setting, allow_nil: false
+           :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
+           :strip_formatting, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
 

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -22,15 +22,16 @@ class InitialStateSerializer < ActiveModel::Serializer
     }
 
     if object.current_account
-      store[:me]              = object.current_account.id.to_s
-      store[:unfollow_modal]  = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]     = object.current_account.user.setting_boost_modal
-      store[:delete_modal]    = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]   = object.current_account.user.setting_auto_play_gif
-      store[:display_media]   = object.current_account.user.setting_display_media
-      store[:expand_spoilers] = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]   = object.current_account.user.setting_reduce_motion
-      store[:is_staff]        = object.current_account.user.staff?
+      store[:me]               = object.current_account.id.to_s
+      store[:unfollow_modal]   = object.current_account.user.setting_unfollow_modal
+      store[:boost_modal]      = object.current_account.user.setting_boost_modal
+      store[:delete_modal]     = object.current_account.user.setting_delete_modal
+      store[:auto_play_gif]    = object.current_account.user.setting_auto_play_gif
+      store[:display_media]    = object.current_account.user.setting_display_media
+      store[:expand_spoilers]  = object.current_account.user.setting_expand_spoilers
+      store[:reduce_motion]    = object.current_account.user.setting_reduce_motion
+      store[:is_staff]         = object.current_account.user.staff?
+      store[:strip_formatting] = object.current_account.user.setting_strip_formatting
     end
 
     store

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -54,6 +54,7 @@
     = f.input :setting_aggregate_reblogs, as: :boolean, wrapper: :with_label
 
   .fields-group
+    = f.input :setting_strip_formatting, collection: ['none', 'blocks', 'all'], wrapper: :with_floating_label, include_blank: false, label_method: lambda { |value| safe_join([I18n.t("statuses.strip_formatting.#{value}"), content_tag(:span, I18n.t("statuses.strip_formatting.#{value}_long"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', hint: false
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label
     = f.input :setting_expand_spoilers, as: :boolean, wrapper: :with_label
     = f.input :setting_reduce_motion, as: :boolean, wrapper: :with_label

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -15,7 +15,7 @@
 
   = account_action_button(status.account)
 
-  .status__content.emojify<
+  .status__content.emojify{ class: text_formatting_classes }<
     - if status.spoiler_text?
       %p{ :style => ('margin-bottom: 0' unless current_account&.user&.setting_expand_spoilers) }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status, autoplay: autoplay)}&nbsp;

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -19,7 +19,7 @@
           %span.display-name__account
             = acct(status.account)
             = fa_icon('lock') if status.account.locked?
-  .status__content.emojify<
+  .status__content.emojify{ class: text_formatting_classes }<
     - if status.spoiler_text?
       %p{ :style => ('margin-bottom: 0' unless current_account&.user&.setting_expand_spoilers) }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status, autoplay: autoplay)}&nbsp;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,6 +848,13 @@ en:
       reblog: A boost cannot be pinned
     show_more: Show more
     sign_in_to_participate: Sign in to participate in the conversation
+    strip_formatting:
+      all: All
+      all_long: Strip all advanced formatting
+      blocks: Block elements
+      blocks_long: Strip formatting for title headers and block quotes
+      none: None
+      none_long: Do not strip any formatting supported by Mastodon
     title: '%{name}: "%{quote}"'
     visibilities:
       private: Followers-only

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -104,6 +104,7 @@ en:
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
+        setting_strip_formatting: Strip advanced formatting from toots
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,6 +32,7 @@ defaults: &defaults
   noindex: false
   theme: 'default'
   aggregate_reblogs: true
+  strip_formatting: 'none'
   notification_emails:
     follow: false
     reblog: false


### PR DESCRIPTION
Support `abbr`, `del`, `pre`, `blockquote`, `code`, `strong`, `b`, `em`, `i`, `u`, `ul`, `ol`, `li` and
`h1` to `h5` tags in remote posts.

Such posts can already be authored in Pleroma and other software, and would currently look something like:

<details>
<summary>Improperly formatted post (as currently displayed)</summary>

![image](https://user-images.githubusercontent.com/384364/57061589-bbfc3e80-6cbd-11e9-923d-c72e3e67feaf.png)
</details>

This PR makes it so it is displayed like this:

![image](https://user-images.githubusercontent.com/384364/57061603-c4547980-6cbd-11e9-9324-ab05bce56957.png)

This is a port of https://github.com/tootsuite/mastodon/pull/10629
It lacks the part exposing the preference in the preference API since the preference API has been introduced in a later version of Mastodon.

The PR also includes a couple options to visually fallback to a text representation (through client-side CSS):

<details>
<summary>Block tags “stripped”</summary>

![image](https://user-images.githubusercontent.com/384364/57061656-ff56ad00-6cbd-11e9-9829-12914b8de692.png)
</details>

<details>
<summary>Everything “stripped”</summary>

![image](https://user-images.githubusercontent.com/384364/57061666-07165180-6cbe-11e9-842d-7b7db1548028.png)
</details>