### PR TITLE
Update Spanish translation to be in line with the English one

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,14 +393,14 @@ en:
         desc_html: Separate multiple usernames by comma. Only local and unlocked accounts will work. Default when empty is all local admins.
         title: Default follows for new users
       contact_information:
-        email: Business e-mail
+        email: Contact e-mail
         username: Contact username
       custom_css:
         desc_html: Modify the look with CSS loaded on every page
         title: Custom CSS
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
-        title: Hero image
+        title: Cover image
       mascot:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,7 @@
 es:
   about:
     about_hashtag_html: Estos son toots públicos etiquetados con <strong>#%{hashtag}</strong>. Puedes interactuar con ellos si tienes una cuenta en cualquier parte del fediverso.
-    about_mastodon_html: Mastodon es un servidor de red social <em>libre y de código abierto</em>. Una alternativa <em>descentralizada</em> a plataformas comerciales, que evita el riesgo de que una única compañía monopolice tu comunicación. Cualquiera puede ejecutar Mastodon y participar sin problemas en la <em>red social</em>.
+    about_mastodon_html: Mastodon es un servidor de red social <em>libre y de código abierto</em>. Una alternativa <em>descentralizada</em> a plataformas comerciales, que evita el riesgo de que una única compañía monopolice su comunicación. Cualquiera puede ejecutar Mastodon y participar sin problemas en la <em>red social</em>.
     about_this: Acerca de esta instancia
     active_count_after: activos
     active_footnote: Usuarios activos mensuales (MAU)
@@ -344,7 +344,7 @@ es:
       disable: Deshabilitar
       disabled: Deshabilitado
       enable: Habilitar
-      enable_hint: Una vez conectado, tu servidor se suscribirá a todos los toots públicos de este relé, y comenzará a enviar los toots públicos de este servidor hacia él.
+      enable_hint: Una vez conectado, su servidor se suscribirá a todos los toots públicos de este relé, y comenzará a enviar los toots públicos de este servidor hacia él.
       enabled: Habilitado
       inbox_url: URL del relé
       pending: Esperando la aprobación del relé
@@ -445,7 +445,7 @@ es:
         desc_html: Párrafo introductorio en la portada y en meta tags. Puedes usar tags HTML, en particular <code>&lt;a&gt;</code> y <code>&lt;em&gt;</code>.
         title: Descripción de instancia
       site_description_extended:
-        desc_html: Un buen lugar para tu código de conducta, reglas, guías y otras cosas que estén impuestas aparte en tu instancia. Puedes usar tags HTML
+        desc_html: Un buen lugar para su código de conducta, reglas, guías y otras cosas que estén impuestas aparte en su instancia. Puedes usar tags HTML
         title: Información extendida personalizada
       site_short_description:
         desc_html: Mostrado en la barra lateral y las etiquetas de metadatos. Describe lo que es Mastodon y qué hace especial a este servidor en un solo párrafo. si está vacío, pone por defecto la descripción de la instancia.
@@ -518,7 +518,7 @@ es:
     regenerate_token: Regenerar token de acceso
     token_regenerated: Token de acceso regenerado exitosamente
     warning: Ten mucho cuidado con estos datos. ¡No los compartas con nadie!
-    your_token: Tu token de acceso
+    your_token: Su identificador de acceso
   auth:
     apply_for_account: Solicitar una invitación
     change_password: Contraseña
@@ -527,7 +527,7 @@ es:
     delete_account: Borrar cuenta
     delete_account_html: Si desea eliminar su cuenta, puede <a href="%{path}">proceder aquí</a>. Será pedido de una confirmación.
     didnt_get_confirmation: "¿No recibió el correo de confirmación?"
-    forgot_password: "¿Olvidaste tu contraseña?"
+    forgot_password: "¿Olvidaste su contraseña?"
     invalid_reset_password_token: El token de reinicio de contraseña es inválido o expiró. Por favor pide uno nuevo.
     login: Iniciar sesión
     logout: Cerrar sesión
@@ -571,10 +571,10 @@ es:
       x_seconds: "%{count}s"
   deletes:
     bad_password_msg: "¡Buen intento, hackers! Contraseña incorrecta"
-    confirm_password: Ingresa tu contraseña actual para demostrar tu identidad
-    description_html: Esto removerá el contenido de tu cuenta y la desactivará <strong>permanente e irrevesiblemente</strong>. Tu nombre de usuario quedará reservado para prevenir futuros robos de identidad.
+    confirm_password: Ingrese su contraseña actual para demostrar su identidad
+    description_html: Esto eliminará el contenido de su cuenta y la desactivará <strong>permanente e irrevesiblemente</strong>. Su nombre de usuario quedará reservado para prevenir futuros robos de identidad.
     proceed: Eliminar cuenta
-    success_msg: Tu cuenta se eliminó con éxito
+    success_msg: Su cuenta se eliminó con éxito
     warning_html: Se garantiza únicamente la eliminación del contenido de esta instancia. El contenido que se haya compartido extensamente dejará sus huellas. Los servidores fuera de línea y los que se hayan desuscrito de tus actualizaciones ya no actualizarán sus bases de datos.
     warning_title: Disponibilidad diseminada del contenido
   directories:
@@ -598,17 +598,17 @@ es:
     '500':
       content: Lo sentimos, algo ha funcionado mal por nuestra parte.
       title: Esta página no es correcta
-    noscript_html: Para usar la aplicación web de Mastodon, por favor activa Javascript. Alternativamente, prueba alguna de las <a href="%{apps_path}">aplicaciones nativas</a> para Mastodon para tu plataforma.
+    noscript_html: Para usar la aplicación web de Mastodon, por favor activa Javascript. Alternativamente, prueba alguna de las <a href="%{apps_path}">aplicaciones nativas</a> para Mastodon para su plataforma.
   existing_username_validator:
     not_found: no se pudo encontrar un usuario local con ese nombre
     not_found_multiple: no se pudo encontrar %{usernames}
   exports:
     archive_takeout:
       date: Fecha
-      download: Descargar tu archivo
+      download: Descargar su archivo
       hint_html: Puedes solicitar un archivo de tus <strong>toots y materiales subidos</strong>. Los datos exportados estarán en formato ActivityPub, legibles por cualquier software compatible.
-      in_progress: Recopilando tu archivo...
-      request: Solicitar tu archivo
+      in_progress: Recopilando su archivo...
+      request: Solicitar su archivo
       size: Tamaño
     blocks: Personas que has bloqueado
     csv: CSV
@@ -676,7 +676,7 @@ es:
       merge_long: Mantener registros actuales y agregar nuevos
       overwrite: Sobrescribir
       overwrite_long: Reemplazar registros actuales con los nuevos
-    preface: Puedes importar ciertos datos, como todas las personas que estás siguiendo o bloqueando en tu cuenta en esta instancia, desde archivos exportados de otra instancia.
+    preface: Puedes importar ciertos datos, como todas las personas que está siguiendo o bloqueando en su cuenta en esta instancia, desde archivos exportados de otra instancia.
     success: Sus datos se han cargado correctamente y serán procesados en brevedad
     types:
       blocking: Lista de bloqueados
@@ -716,26 +716,26 @@ es:
       too_many: No se pueden adjuntar más de 4 archivos
   migrations:
     acct: usuario@dominio de la nueva cuenta
-    currently_redirecting: 'Tu perfil está redireccionado a:'
+    currently_redirecting: 'Su perfil está redireccionado a:'
     proceed: Guardar
-    updated_msg: "¡La configuración de migración de tu cuenta ha sido actualizada exitosamente!"
+    updated_msg: "¡La configuración de migración de su cuenta ha sido actualizada exitosamente!"
   moderation:
     title: Moderación
   notification_mailer:
     digest:
       action: Ver todas las notificaciones
-      body: Un resumen de los mensajes que perdiste en desde tu última visita, el %{since}
+      body: Aquí hay un resumen de los mensajes que perdió desde su última visita el %{since}
       mention: "%{name} te ha mencionado en:"
       new_followers_summary:
         one: "¡Ademas, has adquirido un nuevo seguidor mientras no estabas! ¡Hurra!"
         other: "¡Ademas, has adquirido %{count} nuevos seguidores mientras no estabas! ¡Genial!"
       subject:
-        one: "1 nueva notificación desde tu última visita \U0001F418"
-        other: "%{count} nuevas notificaciones desde tu última visita \U0001F418"
-      title: En tu ausencia…
+        one: "1 nueva notificación desde su última visita \U0001F418"
+        other: "%{count} nuevas notificaciones desde su última visita \U0001F418"
+      title: En su ausencia…
     favourite:
-      body: 'Tu estado fue marcado como favorito por %{name}:'
-      subject: "%{name} marcó tu estado como favorito"
+      body: 'Su estado fue marcado como favorito por %{name}:'
+      subject: "%{name} marcó su estado como favorito"
       title: Nuevo favorito
     follow:
       body: "¡%{name} te está siguiendo!"
@@ -752,8 +752,8 @@ es:
       subject: Fuiste mencionado por %{name}
       title: Nueva mención
     reblog:
-      body: "%{name} promovió tu estado:"
-      subject: "%{name} promovió tu estado"
+      body: "%{name} promovió su estado:"
+      subject: "%{name} promovió su estado"
       title: Nueva difusión
   number:
     human:
@@ -801,8 +801,8 @@ es:
     remove_selected_follows: Dejar de seguir los usuarios seleccionados
     status: Estado de cuenta
   remote_follow:
-    acct: Ingresa tu usuario@dominio desde el que quieres seguir
-    missing_resource: No se pudo encontrar la URL de redirección requerida para tu cuenta
+    acct: Ingrese su usuario@dominio desde donde quiere seguir
+    missing_resource: No se pudo encontrar la URL de redirección requerida para su cuenta
     no_account_html: "¿No tienes una cuenta? Puedes <a href='%{sign_up_path}' target='_blank'>registrarte aqui</a>"
     proceed: Proceder a seguir
     prompt: 'Vas a seguir a:'
@@ -848,7 +848,7 @@ es:
       weibo: Weibo
     current_session: Sesión actual
     description: "%{browser} en %{platform}"
-    explanation: Estos son los navegadores web conectados actualmente en tu cuenta de Mastodon.
+    explanation: Estos son los navegadores web conectados actualmente en su cuenta de Mastodon.
     ip: IP
     platforms:
       adobe_air: Adobe Air
@@ -898,8 +898,8 @@ es:
     boosted_from_html: Impulsado desde %{acct_link}
     content_warning: 'Alerta de contenido: %{warning}'
     disallowed_hashtags:
-      one: 'contenía un hashtag no permitido: %{tags}'
-      other: 'contenía los hashtags no permitidos: %{tags}'
+      one: 'contenía una etiqueta no permitida: %{tags}'
+      other: 'contenía unas etiquetas no permitidas: %{tags}'
     language_detection: Detección automática de idioma
     open_in_web: Abrir en web
     over_character_limit: Límite de caracteres de %{max} superado
@@ -938,7 +938,7 @@ es:
       default: "%d de %b del %Y, %H:%M"
       month: "%b %Y"
   two_factor_authentication:
-    code_hint: Ingresa el código generado por tu aplicación de autenticación para confirmar
+    code_hint: Ingrese el código generado por su aplicación de autenticación para confirmar
     description_html: Si activa la <strong>autenticación de dos factores</strong>, se requerirá estar en posesión de su teléfono, lo que generará autentificadores para que usted pueda iniciar una sesión.
     disable: Deshabilitar
     enable: Habilitar
@@ -976,7 +976,7 @@ es:
         suspend: Cuenta suspendida
     welcome:
       edit_profile_action: Configurar el perfil
-      edit_profile_step: Puedes personalizar tu perfil subiendo un avatar, una cabecera, cambiando su nombre de usuario y más. Si quiere revisar sus nuevos seguidores antes de que se les permita seguirte, puede bloquear su cuenta.
+      edit_profile_step: Puedes personalizar su perfil subiendo un avatar, una cabecera, cambiando su nombre de usuario y más. Si quiere revisar sus nuevos seguidores antes de que se les permita seguirte, puede bloquear su cuenta.
       explanation: Aquí hay algunos consejos para empezar
       final_action: Empezar a publicar
       final_step: '¡Empieza a publicar! Incluso sin seguidores, sus mensajes públicos pueden ser vistos por otros, por ejemplo en la cronología local y con etiquetas. Podría introducirse con la etiqueta #introductions.'
@@ -988,7 +988,7 @@ es:
       tip_federated_timeline: La cronología federada es una vista de la red de Mastodon. Pero solo incluye gente que tus vecinos están siguiendo, así que no está completa.
       tip_following: Sigues a tus administradores de servidor por defecto. Para encontrar más gente interesante, revisa las cronologías locales y federadas.
       tip_local_timeline: La cronología local es una vista de la gente en %{instance}. Estos son tus vecinos inmediatos!
-      tip_mobile_webapp: Si el navegador de tu dispositivo móvil ofrece agregar Mastodon a tu página de inicio, puedes recibir notificaciones. Actúa como una aplicación nativa en muchas formas!
+      tip_mobile_webapp: Si el navegador de su dispositivo móvil ofrece agregar Mastodon a su página de inicio, puede recibir notificaciones. Actúa como una aplicación nativa en muchas formas!
       tips: Consejos
       title: ¡Te damos la bienvenida a bordo, %{name}!
   users:
@@ -999,5 +999,5 @@ es:
     seamless_external_login: Has iniciado sesión desde un servicio externo, así que los ajustes de contraseña y correo no están disponibles.
     signed_in_as: 'Sesión iniciada como:'
   verification:
-    explanation_html: 'Puedes <strong>verificarte a ti mismo como el dueño de los links en los metadatos de tu perfil</strong>. Para eso, el sitio vinculado debe contener un vínculo a tu perfil de Mastodon. El vínculo en tu sitio <strong>debe</strong> tener un atributo <code>rel="me"</code>. El texto del vínculo no importa. Aquí hay un ejemplo:'
+    explanation_html: 'Puede <strong>verificarse a si mismo como el dueño de los enlaces en los metadatos de su perfil</strong>. Para eso, el sitio vinculado debe contener un vínculo a su perfil de Mastodon. El vínculo en su sitio <strong>debe</strong> tener un atributo <code>rel="me"</code>. El texto del vínculo no importa. Aquí hay un ejemplo:'
     verification: Verificación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -22,7 +22,7 @@ es:
       <p>La descripción extendida no se ha colocado aún.</p>
     federation_hint_html: Con una cuenta en %{instance} podrás seguir gente en cualquier servidor de Mastodon
     generic_description: "%{domain} es un servidor en la red"
-    get_apps: "Prueba una aplicación movil"
+    get_apps: Prueba una aplicación movil
     hosted_on: Mastodon hosteado en %{domain}
     learn_more: Aprende más
     privacy_policy: Política de privacidad
@@ -310,7 +310,7 @@ es:
       title: Lista negra de correo
     followers:
       back_to_account: Regresar A Cuenta
-      title: "Seguidores de %{acct}"
+      title: Seguidores de %{acct}
     instances:
       by_domain: Dominio
       delivery_available: Distribución está disponible
@@ -583,7 +583,7 @@ es:
     enabled_but_waiting: Usted ha optado por estar en el directorio, pero no tiene el número mínimo de seguidores (%{min_followers}) para ser listado todavía.
     explanation: Descubre usuarios por sus intereses
     explore_mastodon: Explora %{title}
-    how_to_enable: "Actualmente no a optado por estar en el directorio. Puede optar abajo. ¡Usa etiquetas en su biografía para ser listado bajo etiquetas especificas!"
+    how_to_enable: Actualmente no a optado por estar en el directorio. Puede optar abajo. ¡Usa etiquetas en su biografía para ser listado bajo etiquetas especificas!
     people:
       one: "%{count} persona"
       other: "%{count} personas"
@@ -667,7 +667,7 @@ es:
     identity: Identidad
     inactive: Inactivo
     publicize_checkbox: 'E incluye esto:'
-    publicize_toot: '¡Está comprobado! Soy %{username} en %{service}: %{url}'
+    publicize_toot: "¡Está comprobado! Soy %{username} en %{service}: %{url}"
     status: Estado de verificación
     view_proof: Ver prueba
   imports:
@@ -979,7 +979,7 @@ es:
       edit_profile_step: Puedes personalizar su perfil subiendo un avatar, una cabecera, cambiando su nombre de usuario y más. Si quiere revisar sus nuevos seguidores antes de que se les permita seguirte, puede bloquear su cuenta.
       explanation: Aquí hay algunos consejos para empezar
       final_action: Empezar a publicar
-      final_step: '¡Empieza a publicar! Incluso sin seguidores, sus mensajes públicos pueden ser vistos por otros, por ejemplo en la cronología local y con etiquetas. Podría introducirse con la etiqueta #introductions.'
+      final_step: "¡Empieza a publicar! Incluso sin seguidores, sus mensajes públicos pueden ser vistos por otros, por ejemplo en la cronología local y con etiquetas. Podría introducirse con la etiqueta #introductions."
       full_handle: Su sobrenombre completo
       full_handle_hint: Esto es lo que le dirías a tus amigos para que ellos puedan enviarle mensajes o seguirle desde otra instancia.
       review_preferences_action: Cambiar preferencias
@@ -990,7 +990,7 @@ es:
       tip_local_timeline: La cronología local es una vista de la gente en %{instance}. Estos son tus vecinos inmediatos!
       tip_mobile_webapp: Si el navegador de su dispositivo móvil ofrece agregar Mastodon a su página de inicio, puede recibir notificaciones. Actúa como una aplicación nativa en muchas formas!
       tips: Consejos
-      title: ¡Te damos la bienvenida a bordo, %{name}!
+      title: "¡Te damos la bienvenida a bordo, %{name}!"
   users:
     follow_limit_reached: No puedes seguir a más de %{limit} personas
     invalid_email: La dirección de correo es incorrecta

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,25 +4,36 @@ es:
     about_hashtag_html: Estos son toots públicos etiquetados con <strong>#%{hashtag}</strong>. Puedes interactuar con ellos si tienes una cuenta en cualquier parte del fediverso.
     about_mastodon_html: Mastodon es un servidor de red social <em>libre y de código abierto</em>. Una alternativa <em>descentralizada</em> a plataformas comerciales, que evita el riesgo de que una única compañía monopolice tu comunicación. Cualquiera puede ejecutar Mastodon y participar sin problemas en la <em>red social</em>.
     about_this: Acerca de esta instancia
+    active_count_after: activos
+    active_footnote: Usuarios activos mensuales (MAU)
     administered_by: 'Administrado por:'
     api: API
     apps: Aplicaciones móviles
+    apps_platforms: Usa Mastodon desde iOS, Android, y otras plataformas
+    browse_directory: Revisa un directorio de perfiles y filtra por intereses
+    browse_public_posts: Revisa una transmisión en vivo de publicaciones en Mastodon
     contact: Contacto
     contact_missing: No especificado
     contact_unavailable: N/A
+    discover_users: Descubre usuarios
     documentation: Documentación
     extended_description_html: |
       <h3>Un buen lugar para las reglas</h3>
       <p>La descripción extendida no se ha colocado aún.</p>
+    federation_hint_html: Con una cuenta en %{instance} podrás seguir gente en cualquier servidor de Mastodon
     generic_description: "%{domain} es un servidor en la red"
+    get_apps: "Prueba una aplicación movil"
     hosted_on: Mastodon hosteado en %{domain}
     learn_more: Aprende más
     privacy_policy: Política de privacidad
+    see_whats_happening: Ver que pasa
+    server_stats: 'Estadísticas de servidor:'
     source_code: Código fuente
     status_count_after:
       one: estado
       other: estados
     status_count_before: Qué han escrito
+    tagline: Sigue y descubre nuevos amigos
     terms: Condiciones de servicio
     user_count_after:
       one: usuario
@@ -57,9 +68,11 @@ es:
       admin: Administrador
       bot: Bot
       moderator: Moderador
+    unavailable: Perfil no disponible
     unfollow: Dejar de seguir
   admin:
     account_actions:
+      action: Moderar
       title: Moderar %{acct}
     account_moderation_notes:
       create: Crear
@@ -67,6 +80,8 @@ es:
       delete: Borrar
       destroyed_msg: "¡Nota de moderación destruida con éxito!"
     accounts:
+      approve: Aprobar
+      approve_all: Aprobar todos
       are_you_sure: "¿Estás seguro?"
       avatar: Avatar
       by_domain: Dominio
@@ -100,6 +115,7 @@ es:
       inbox_url: URL de la bandeja de entrada
       invited_by: Invitado por
       ip: IP
+      joined: Se unió
       location:
         all: Todos
         local: Local
@@ -111,15 +127,18 @@ es:
       moderation:
         active: Activo
         all: Todos
+        pending: Pendiente
         silenced: Silenciados
         suspended: Suspendidos
         title: Moderación
       moderation_notes: Notas de moderación
       most_recent_activity: Actividad más reciente
       most_recent_ip: IP más reciente
+      no_account_selected: No se cambiaron las cuentas ya que ninguna fue seleccionada
       no_limits_imposed: Sin límites impuestos
       not_subscribed: No se está suscrito
       outbox_url: URL de bandeja de salida
+      pending: Revisión pendiente
       perform_full_suspension: Suspender
       profile_url: URL del perfil
       promote: Promocionar
@@ -127,7 +146,10 @@ es:
       public: Público
       push_subscription_expires: Expiración de la suscripción PuSH
       redownload: Refrescar avatar
+      reject: Rechazar
+      reject_all: Rechazar todos
       remove_avatar: Eliminar el avatar
+      remove_header: Eliminar el encabezado
       resend_confirmation:
         already_confirmed: Este usuario ya está confirmado
         send: Reenviar el correo electrónico de confirmación
@@ -145,8 +167,8 @@ es:
       search: Buscar
       shared_inbox_url: URL de bandeja compartida
       show:
-        created_reports: Reportes hechos por esta cuenta
-        targeted_reports: Reportes hechos sobre esta cuenta
+        created_reports: Denuncias hechos por esta cuenta
+        targeted_reports: Denuncias hechos sobre esta cuenta
       silence: Silenciar
       silenced: Silenciado
       statuses: Estados
@@ -158,12 +180,14 @@ es:
       undo_suspension: Des-suspender
       unsubscribe: Desuscribir
       username: Nombre de usuario
+      warn: Advertir
       web: Web
     action_logs:
       actions:
         assigned_to_self_report: "%{name} se ha asignado la denuncia %{target} a sí mismo"
         change_email_user: "%{name} ha cambiado la dirección de correo del usuario %{target}"
         confirm_user: "%{name} confirmó la dirección de correo del usuario %{target}"
+        create_account_warning: "%{name} envió una advertencia a %{target}"
         create_custom_emoji: "%{name} subió un nuevo emoji %{target}"
         create_domain_block: "%{name} bloqueó el dominio %{target}"
         create_email_domain_block: "%{name} puso en lista negra el dominio de correos %{target}"
@@ -222,11 +246,13 @@ es:
       config: Configuración
       feature_deletions: Borrados de cuenta
       feature_invites: Enlaces de invitación
+      feature_profile_directory: Directorio de perfiles
       feature_registrations: Registros
       feature_relay: Relés de federación
+      feature_timeline_preview: Vista previa de la cronología
       features: Características
       hidden_service: Federación con servicios ocultos
-      open_reports: informes abiertos
+      open_reports: denuncias abiertas
       recent_users: Usuarios recientes
       search: Búsqueda por texto completo
       single_user_mode: Modo único usuario
@@ -243,6 +269,7 @@ es:
       created_msg: El bloque de dominio está siendo procesado
       destroyed_msg: El bloque de dominio se deshizo
       domain: Dominio
+      existing_domain_block_html: Ya ha impuesto límites más estrictos en %{name}, primero debe <a href="%{unblock_url}">desbloquearlo</a>.
       new:
         create: Crear bloque
         hint: El bloque de dominio no prevendrá la creación de entradas de cuenta en la base de datos, pero aplicará retroactiva y automáticamente métodos de moderación específica en dichas cuentas.
@@ -254,8 +281,13 @@ es:
         title: Nuevo bloque de dominio
       reject_media: Rechazar archivos multimedia
       reject_media_hint: Remueve localmente archivos multimedia almacenados para descargar cualquiera en el futuro. Irrelevante para suspensiones
-      reject_reports: Rechazar informes
-      reject_reports_hint: Ignore todos los reportes de este dominio. Irrelevante para suspensiones
+      reject_reports: Rechazar denuncias
+      reject_reports_hint: Ignorar todas las denuncias de este dominio. Irrelevante para suspensiones
+      rejecting_media: rechazando archivos multimedia
+      rejecting_reports: rechazando denuncias
+      severity:
+        silence: silenciado
+        suspend: suspendido
       show:
         affected_accounts:
           one: Una cuenta en la base de datos afectada
@@ -265,7 +297,7 @@ es:
           suspend: Des-suspender todas las cuentas existentes de este dominio
         title: Deshacer bloque de dominio para %{domain}
         undo: Deshacer
-      undo: Deshacer
+      undo: Deshacer bloque de dominio
     email_domain_blocks:
       add_new: Añadir nuevo
       created_msg: Dominio de correo añadido a la lista negra con éxito
@@ -276,8 +308,25 @@ es:
         create: Añadir dominio
         title: Nueva entrada en la lista negra de correo
       title: Lista negra de correo
+    followers:
+      back_to_account: Regresar A Cuenta
+      title: "Seguidores de %{acct}"
     instances:
+      by_domain: Dominio
+      delivery_available: Distribución está disponible
+      known_accounts:
+        one: "%{count} cuenta conocida"
+        other: "%{count} cuentas conocidas"
+      moderation:
+        all: Todo
+        limited: Limitado
+        title: Moderación
       title: Instancias conocidas
+      total_blocked_by_us: Bloqueado por nosotros
+      total_followed_by_them: Seguido por ellos
+      total_followed_by_us: Seguido por nosotros
+      total_reported: Denuncias sobre ellos
+      total_storage: Archivos adjuntos
     invites:
       deactivate_all: Desactivar todos
       filter:
@@ -286,21 +335,23 @@ es:
         expired: Expiradas
         title: Filtrar
       title: Invitaciones
+    pending_accounts:
+      title: Cuentas pendientes (%{count})
     relays:
-      add_new: Añadir un nuevo relés
+      add_new: Añadir nuevo relé
       delete: Borrar
-      description_html: Un <strong>relés de federation</strong> es un servidor intermedio que intercambia grandes volúmenes de toots públicos entre servidores que se suscriben y publican en él. <strong>Puede ayudar a servidores pequeños y medianos a descubir contenido del fediverso</strong>, que de otra manera requeriría que los usuarios locales siguiesen manialmente a personas de servidores remotos.
+      description_html: Un <strong>relé de federación</strong> es un servidor intermedio que intercambia grandes volúmenes de toots públicos entre servidores que se suscriben y publican en él. <strong>Puede ayudar a servidores pequeños y medianos a descubir contenido del fediverso</strong>, que de otra manera requeriría que los usuarios locales siguiesen a mano a personas de servidores remotos.
       disable: Deshabilitar
       disabled: Deshabilitado
-      enable: Hablitar
-      enable_hint: Una vez conectado, tu servidor se suscribirá a todos los toots públicos de este relés, y comenzará a enviar los toots públicos de este servidor hacia él.
+      enable: Habilitar
+      enable_hint: Una vez conectado, tu servidor se suscribirá a todos los toots públicos de este relé, y comenzará a enviar los toots públicos de este servidor hacia él.
       enabled: Habilitado
-      inbox_url: URL del relés
-      pending: Esperando la aprobación del relés
+      inbox_url: URL del relé
+      pending: Esperando la aprobación del relé
       save_and_enable: Guardar y conectar
-      setup: Preparar una conexión de relés
+      setup: Preparar una conexión de relé
       status: Estado
-      title: Releses
+      title: Relés
     report_notes:
       created_msg: "¡El registro de la denuncia se ha creado correctamente!"
       destroyed_msg: "¡El registro de la denuncia se ha borrado correctamente!"
@@ -310,7 +361,7 @@ es:
         report: denuncia
       action_taken_by: Acción tomada por
       are_you_sure: "¿Estás seguro?"
-      assign_to_self: Asignármela a mí
+      assign_to_self: Asignár a mí
       assigned: Moderador asignado
       comment:
         none: Ninguno
@@ -324,25 +375,25 @@ es:
         delete: Eliminar
         placeholder: Especificar qué acciones se han tomado o cualquier otra novedad respecto a esta denuncia…
       reopen: Reabrir denuncia
-      report: 'Reportar #%{id}'
-      reported_account: Cuenta reportada
-      reported_by: Reportado por
+      report: 'Denunciar #%{id}'
+      reported_account: Cuenta denunciada
+      reported_by: Denunciado por
       resolved: Resuelto
       resolved_msg: "¡La denuncia se ha resuelto correctamente!"
       status: Estado
-      title: Reportes
+      title: Denuncias
       unassign: Desasignar
       unresolved: No resuelto
       updated_at: Actualizado
     settings:
       activity_api_enabled:
-        desc_html: Conteo de estados publicados localmente, usuarios activos, y nuevos registros en  periodos semanales
-        title: Publicar estadísticas locales acerca de actividad de usuario
+        desc_html: Conteo de estados publicados localmente, usuarios activos, y nuevos registros en periodos semanales
+        title: Publicar estadísticas agregado acerca de actividad de usuario
       bootstrap_timeline_accounts:
         desc_html: Separa con comas los nombres de usuario. Solo funcionará para cuentas locales desbloqueadas. Si se deja vacío, se tomará como valor por defecto a todos los administradores locales.
         title: Seguimientos predeterminados para usuarios nuevos
       contact_information:
-        email: Correo de trabajo
+        email: Correo electrónico
         username: Nombre de usuario
       custom_css:
         desc_html: Modificar el aspecto con CSS cargado en cada página
@@ -353,12 +404,21 @@ es:
       mascot:
         desc_html: Mostrado en múltiples páginas. Se recomienda un tamaño mínimo de 293x205px. Cuando no se especifica, se muestra la mascota por defecto
         title: Imagen de la mascota
+      max_bio_chars:
+        desc_html: 'Fijar longitud maxima de la biografía en carácteres (defecto: 500)'
+        title: Tamaño maximo de la biografía
+      max_toot_chars:
+        desc_html: 'Fijar longitud maxima de un toot en carácteres (defecto: 500)'
+        title: Tamaño maximo de un toot
       peers_api_enabled:
         desc_html: Nombres de dominio que esta instancia ha encontrado en el fediverso
         title: Publicar lista de instancias descubiertas
       preview_sensitive_media:
         desc_html: Los enlaces de vistas previas en otras web mostrarán una miniatura incluso si el medio está marcado como contenido sensible
         title: Mostrar contenido sensible en previews de OpenGraph
+      profile_directory:
+        desc_html: Permitir que los usuarios sean encontrables
+        title: Activar directorio de perfiles
       registrations:
         closed_message:
           desc_html: Se muestra en la portada cuando los registros están cerrados. Puedes usar tags HTML
@@ -369,6 +429,12 @@ es:
         min_invite_role:
           disabled: Nadie
           title: Permitir invitaciones de
+      registrations_mode:
+        modes:
+          approved: Aprobación requerida para registrarse
+          none: Nadie puede registrarse
+          open: Cualquiera puede registrarse
+        title: Modo de registraciones
       show_known_fediverse_at_about_page:
         desc_html: Cuando esté activado, se mostrarán toots de todo el fediverso conocido en la vista previa. En otro caso, se mostrarán solamente toots locales.
         title: Mostrar fediverso conocido en la vista previa de la historia
@@ -392,7 +458,7 @@ es:
         desc_html: Se usa para muestras con OpenGraph y APIs. Se recomienda 1200x630px
         title: Portada de instancia
       timeline_preview:
-        desc_html: Mostrar línea de tiempo pública en la portada
+        desc_html: Mostrar cronología pública en la portada
         title: Previsualización
       title: Ajustes del sitio
     statuses:
@@ -415,12 +481,29 @@ es:
       last_delivery: Última entrega
       title: WebSub
       topic: Tópico
+    tags:
+      accounts: Cuentas
+      hidden: Oculto
+      hide: Ocultar del directorio
+      name: Etiqueta
+      title: Etiquetas
+      unhide: Mostrar en el directorio
+      visible: Visible
     title: Administración
+    warning_presets:
+      add_new: Añadir nuevo
+      delete: Eliminar
+      edit: Editar
+      edit_preset: Editar preajuste de advertencia
+      title: Administrar preajuste de advertencia
   admin_mailer:
+    new_pending_account:
+      body: Los detalles de la cuenta nueva estan abajo. Puedes aprobar o rechazar esta aplicación.
+      subject: Cuenta nueva para revisión en %{instance} (%{username})
     new_report:
-      body: "%{reporter} ha reportado a %{target}"
-      body_remote: Alguien de %{domain} a reportado a %{target}
-      subject: Nuevo reporte para la %{instance} (#%{id})
+      body: "%{reporter} ha denunciado a %{target}"
+      body_remote: Alguien de %{domain} a denunciado a %{target}
+      subject: Denuncia nueva para %{instance} (#%{id})
   application_mailer:
     notification_preferences: Cambiar preferencias de correo electrónico
     salutation: "%{name},"
@@ -437,8 +520,10 @@ es:
     warning: Ten mucho cuidado con estos datos. ¡No los compartas con nadie!
     your_token: Tu token de acceso
   auth:
+    apply_for_account: Solicitar una invitación
     change_password: Contraseña
-    confirm_email: Confirmar email
+    checkbox_agreement_html: Estoy de acuerdo con las <a href="%{rules_path}" target="_blank">reglas del servidor</a> y los <a href="%{terms_path}" target="_blank">terminos de servicio</a>.
+    confirm_email: Confirmar correo electrónico
     delete_account: Borrar cuenta
     delete_account_html: Si desea eliminar su cuenta, puede <a href="%{path}">proceder aquí</a>. Será pedido de una confirmación.
     didnt_get_confirmation: "¿No recibió el correo de confirmación?"
@@ -453,10 +538,12 @@ es:
       cas: CAS
       saml: SAML
     register: Registrarse
+    registration_closed: "%{instance} no esta aceptando miembros nuevos"
     resend_confirmation: Volver a enviar el correo de confirmación
     reset_password: Restablecer contraseña
     security: Cambiar contraseña
     set_new_password: Establecer nueva contraseña
+    trouble_logging_in: "¿Problemas iniciando la sesión?"
   authorize_follow:
     already_following: Ya estás siguiendo a esta cuenta
     error: Desafortunadamente, ha ocurrido un error buscando la cuenta remota
@@ -472,14 +559,14 @@ es:
     distance_in_words:
       about_x_hours: "%{count}h"
       about_x_months: "%{count}m"
-      about_x_years: "%{count}y"
-      almost_x_years: "%{count}y"
+      about_x_years: "%{count}a"
+      almost_x_years: "%{count}a"
       half_a_minute: Justo ahora
-      less_than_x_minutes: "%{count}m"
+      less_than_x_minutes: "%{count}min"
       less_than_x_seconds: Justo ahora
       over_x_years: "%{count}y"
       x_days: "%{count}d"
-      x_minutes: "%{count}m"
+      x_minutes: "%{count}min"
       x_months: "%{count}m"
       x_seconds: "%{count}s"
   deletes:
@@ -490,6 +577,16 @@ es:
     success_msg: Tu cuenta se eliminó con éxito
     warning_html: Se garantiza únicamente la eliminación del contenido de esta instancia. El contenido que se haya compartido extensamente dejará sus huellas. Los servidores fuera de línea y los que se hayan desuscrito de tus actualizaciones ya no actualizarán sus bases de datos.
     warning_title: Disponibilidad diseminada del contenido
+  directories:
+    directory: Directorio de perfiles
+    enabled: Usted está actualmente en el directorio.
+    enabled_but_waiting: Usted ha optado por estar en el directorio, pero no tiene el número mínimo de seguidores (%{min_followers}) para ser listado todavía.
+    explanation: Descubre usuarios por sus intereses
+    explore_mastodon: Explora %{title}
+    how_to_enable: "Actualmente no a optado por estar en el directorio. Puede optar abajo. ¡Usa etiquetas en su biografía para ser listado bajo etiquetas especificas!"
+    people:
+      one: "%{count} persona"
+      other: "%{count} personas"
   errors:
     '403': No tienes permiso para acceder a esta página.
     '404': La página que estabas buscando no existe.
@@ -502,6 +599,9 @@ es:
       content: Lo sentimos, algo ha funcionado mal por nuestra parte.
       title: Esta página no es correcta
     noscript_html: Para usar la aplicación web de Mastodon, por favor activa Javascript. Alternativamente, prueba alguna de las <a href="%{apps_path}">aplicaciones nativas</a> para Mastodon para tu plataforma.
+  existing_username_validator:
+    not_found: no se pudo encontrar un usuario local con ese nombre
+    not_found_multiple: no se pudo encontrar %{usernames}
   exports:
     archive_takeout:
       date: Fecha
@@ -512,14 +612,20 @@ es:
       size: Tamaño
     blocks: Personas que has bloqueado
     csv: CSV
+    domain_blocks: Bloques de dominio
     follows: Personas que sigues
+    lists: Listas
     mutes: Tienes en silencio
     storage: Almacenamiento
+  featured_tags:
+    add_new: Añadir nuevo
+    errors:
+      limit: Ya ha exhibido la cantidad máxima de etiquetas
   filters:
     contexts:
-      home: Timeline propio
+      home: Cronología propio
       notifications: Notificaciones
-      public: Timeline público
+      public: Cronología público
       thread: Conversaciones
     edit:
       title: Editar filtro
@@ -533,23 +639,51 @@ es:
       title: Añadir un nuevo filtro
   footer:
     developers: Desarrolladores
-    more: Mas…
+    more: Más…
     resources: Recursos
   generic:
+    all: Todo
     changes_saved_msg: "¡Cambios guardados con éxito!"
     copy: Copiar
+    order_by: Ordenar por
     save_changes: Guardar cambios
     validation_errors:
       one: "¡Algo no está bien! Por favor, revisa el error"
       other: "¡Algo no está bien! Por favor, revise %{count} errores más abajo"
+  html_validator:
+    invalid_markup: 'contiene marcado de HTML inválido: %{error}'
+  identity_proofs:
+    active: Activo
+    authorize: Sí, autorizar
+    authorize_connection_prompt: Autorizar esta conección criptográfica?
+    errors:
+      failed: La conección criptográfica falló. Por favor inténtelo de nuevo desde %{provider}.
+      keybase:
+        invalid_token: Los identificadores de Keybase son rusumenes criptográficos de firmas y deben ser 66 carácteres hexadecimales
+        verification_failed: Keybase no reconoce este identificador como una firma del usuario de Keybase %{kb_username}. Por favor vuelva a intentarlo desde Keybase.
+      wrong_user: No se puede crear una prueba para %{proving} mientras conectado como %{current}. Conectese como %{proving} e intente de nuevo.
+    explanation_html: Aquí puede conectar criptograficamente a sus otras identidades, como un perfil de Keybase. Esto deja que otras personas les mande mensajes cifrados y confiar en el contenido que reciban de usted.
+    i_am_html: Soy %{username} en %{service}.
+    identity: Identidad
+    inactive: Inactivo
+    publicize_checkbox: 'E incluye esto:'
+    publicize_toot: '¡Está comprobado! Soy %{username} en %{service}: %{url}'
+    status: Estado de verificación
+    view_proof: Ver prueba
   imports:
+    modes:
+      merge: Unir
+      merge_long: Mantener registros actuales y agregar nuevos
+      overwrite: Sobrescribir
+      overwrite_long: Reemplazar registros actuales con los nuevos
     preface: Puedes importar ciertos datos, como todas las personas que estás siguiendo o bloqueando en tu cuenta en esta instancia, desde archivos exportados de otra instancia.
     success: Sus datos se han cargado correctamente y serán procesados en brevedad
     types:
       blocking: Lista de bloqueados
+      domain_blocking: Lista de dominios bloqueados
       following: Lista de seguidos
       muting: Lista de silenciados
-    upload: Cargar
+    upload: Subir
   in_memoriam_html: En memoria.
   invites:
     delete: Desactivar
@@ -572,7 +706,7 @@ es:
     table:
       expires_at: Expira
       uses: Usos
-    title: Invitar a gente
+    title: Invitar a la gente
   lists:
     errors:
       limit: Has alcanzado la cantidad máxima de listas
@@ -581,10 +715,10 @@ es:
       images_and_video: No se puede adjuntar un video a un estado que ya contenga imágenes
       too_many: No se pueden adjuntar más de 4 archivos
   migrations:
-    acct: username@domain de la nueva cuenta
+    acct: usuario@dominio de la nueva cuenta
     currently_redirecting: 'Tu perfil está redireccionado a:'
     proceed: Guardar
-    updated_msg: "¡La configuración de migración de tu cuenta  ha sido actualizada con éxito!"
+    updated_msg: "¡La configuración de migración de tu cuenta ha sido actualizada exitosamente!"
   moderation:
     title: Moderación
   notification_mailer:
@@ -601,7 +735,7 @@ es:
       title: En tu ausencia…
     favourite:
       body: 'Tu estado fue marcado como favorito por %{name}:'
-      subject: "%{name} marcó como favorito tu estado"
+      subject: "%{name} marcó tu estado como favorito"
       title: Nuevo favorito
     follow:
       body: "¡%{name} te está siguiendo!"
@@ -618,8 +752,8 @@ es:
       subject: Fuiste mencionado por %{name}
       title: Nueva mención
     reblog:
-      body: "%{name} ha retooteado tu estado:"
-      subject: "%{name} ha retooteado tu estado"
+      body: "%{name} promovió tu estado:"
+      subject: "%{name} promovió tu estado"
       title: Nueva difusión
   number:
     human:
@@ -631,28 +765,66 @@ es:
           quadrillion: Q
           thousand: K
           trillion: T
-          unit: " "
+          unit: ''
   pagination:
     newer: Más nuevo
     next: Próximo
     older: Más antiguo
     prev: Anterior
     truncate: "&hellip;"
+  polls:
+    errors:
+      already_voted: Ya has votado en esta encuesta
+      duplicate_options: contiene opciones duplicadas
+      duration_too_long: es muy lejos en el futuro
+      duration_too_short: es muy pronto
+      expired: La encuesta ya se ha terminado
+      over_character_limit: no puede tener más de %{max} carácteres cada uno
+      too_few_options: debe tener mas de una opción
+      too_many_options: no puede tener mas de %{max} opciones
   preferences:
     languages: Idiomas
     other: Otros
     publishing: Publicación
     web: Web
+  relationships:
+    activity: Actividad de cuenta
+    dormant: Latente
+    last_active: Última vez activo
+    most_recent: Más reciente
+    moved: Movido
+    mutual: Mutuo
+    primary: Primario
+    relationship: Relación
+    remove_selected_domains: Eliminar todos los seguidores de los dominios seleccionados
+    remove_selected_followers: Eliminar los seguidores seleccionados
+    remove_selected_follows: Dejar de seguir los usuarios seleccionados
+    status: Estado de cuenta
   remote_follow:
-    acct: Ingesa tu usuario@dominio desde el que quieres seguir
+    acct: Ingresa tu usuario@dominio desde el que quieres seguir
     missing_resource: No se pudo encontrar la URL de redirección requerida para tu cuenta
     no_account_html: "¿No tienes una cuenta? Puedes <a href='%{sign_up_path}' target='_blank'>registrarte aqui</a>"
     proceed: Proceder a seguir
     prompt: 'Vas a seguir a:'
+    reason_html: "<strong>¿Por qué es este paso necesario?</strong> Pueda que <code>%{instance}</code> no sea el servidor donde esté registrado, entonces necesitamos redirigirle a su servidor primero."
+  remote_interaction:
+    favourite:
+      proceed: Preceder a hacer un favorito
+      prompt: 'Quieres hacer este toot un favorito:'
+    reblog:
+      proceed: Preceder a promover
+      prompt: 'Quieres promover este toot:'
+    reply:
+      proceed: Preceder a responder
+      prompt: 'Quieres responder a este toot:'
   remote_unfollow:
     error: Error
     title: Título
     unfollowed: Ha dejado de seguirse
+  scheduled_statuses:
+    over_daily_limit: Ha excedido el limite de %{limit} toots programados por ese día
+    over_total_limit: Ha excedido el limite de %{limit} toots programados
+    too_soon: La fecha programada debe de estar en el futuro
   sessions:
     activity: Última actividad
     browser: Navegador
@@ -663,7 +835,7 @@ es:
       edge: Microsoft Edge
       electron: Electron
       firefox: Firefox
-      generic: Desconocido
+      generic: Navegador desconocido
       ie: Internet Explorer
       micro_messenger: MicroMessenger
       nokia: Nokia S40 Ovi Browser
@@ -695,16 +867,24 @@ es:
     revoke_success: Sesión revocada exitosamente
     title: Sesiones
   settings:
+    account: Cuenta
+    account_settings: Configuraciones de la cuenta
+    appearance: Apariencia
     authorized_apps: Aplicaciones autorizadas
     back: Volver al inicio
     delete: Borrar cuenta
     development: Desarrollo
     edit_profile: Editar perfil
     export: Exportar información
+    featured_tags: Etiquetas destacadas
+    identity_proofs: Pruebas de identidad
     import: Importar
+    import_and_export: Importar y exportar
     migrate: Migración de cuenta
     notifications: Notificaciones
     preferences: Preferencias
+    profile: Perfil
+    relationships: Siguientes y seguidores
     two_factor_authentication: Autenticación de dos factores
   statuses:
     attached:
@@ -728,6 +908,11 @@ es:
       ownership: El toot de alguien más no puede fijarse
       private: Los toots no-públicos no pueden fijarse
       reblog: Un boost no puede fijarse
+    poll:
+      total_votes:
+        one: "%{count} voto"
+        other: "%{count} votos"
+      vote: Votar
     show_more: Mostrar más
     sign_in_to_participate: Regístrate para participar en la conversación
     title: '%{name}: "%{quote}"'
@@ -737,16 +922,16 @@ es:
       public: Público
       public_long: Todos pueden ver
       unlisted: Público, pero no mostrar en la historia federada
-      unlisted_long: Todos pueden ver, pero no está listado en las líneas de tiempo públicas
+      unlisted_long: Todos pueden ver, pero no está listado en las cronologías públicas
   stream_entries:
     pinned: Toot fijado
-    reblogged: retooteado
+    reblogged: promovió
     sensitive_content: Contenido sensible
   terms:
     title: Términos del Servicio y Políticas de Privacidad de %{instance}
   themes:
     contrast: Alto contraste
-    default: Mastodon
+    default: Mastodon (oscuro)
     mastodon-light: Mastodon (claro)
   time:
     formats:
@@ -754,42 +939,58 @@ es:
       month: "%b %Y"
   two_factor_authentication:
     code_hint: Ingresa el código generado por tu aplicación de autenticación para confirmar
-    description_html: Si habilitas la <strong>autenticación de dos factores</strong>, se requerirá estar en posesión de su teléfono, lo que generará tokens para que usted pueda iniciar sesión.
+    description_html: Si activa la <strong>autenticación de dos factores</strong>, se requerirá estar en posesión de su teléfono, lo que generará autentificadores para que usted pueda iniciar una sesión.
     disable: Deshabilitar
     enable: Habilitar
     enabled: La autenticación de dos factores está activada
     enabled_success: Verificación de dos factores activada exitosamente
     generate_recovery_codes: generar códigos de recuperación
     instructions_html: "<strong>Escanea este código QR desde Google Authenticator o una aplicación similar en su teléfono</strong>. Desde ahora, esta aplicación va a generar tokens que tienes que ingresar cuando quieras iniciar sesión."
-    lost_recovery_codes: Los códigos de recuperación te permiten obtener acceso a tu cuenta si pierdes tu teléfono. Si has perdido tus códigos de recuperación, puedes regenerarlos aquí. Tus viejos códigos de recuperación se harán inválidos.
+    lost_recovery_codes: Los códigos de recuperación le permite obtener acceso a su cuenta si pierde su teléfono. Si ha perdido sus códigos de recuperación, puede regenerarlos aquí. Sus viejos códigos de recuperación se harán inválidos.
     manual_instructions: 'Si no puedes escanear el código QR y necesitas introducirlo manualmente, este es el secreto en texto plano:'
-    recovery_codes: Hacer copias de seguridad de tus códigos de recuperación
+    recovery_codes: Hacer copias de seguridad de sus códigos de recuperación
     recovery_codes_regenerated: Códigos de recuperación regenerados con éxito
-    recovery_instructions_html: Si pierdes acceso a tu teléfono, puedes usar uno de los siguientes códigos de recuperación para obtener acceso a tu cuenta. <strong>Mantenlos a salvo</strong>. Por ejemplo, puedes imprimirlos y guardarlos con otros documentos importantes.
+    recovery_instructions_html: Si pierde acceso a su teléfono, puede usar uno de los siguientes códigos de recuperación para obtener acceso a su cuenta. <strong>Mantenlos a salvo</strong>. Por ejemplo, puede imprimirlos y guardarlos con otros documentos importantes.
     setup: Configurar
     wrong_code: "¡El código ingresado es inválido! ¿El dispositivo y tiempo del servidor están correctos?"
   user_mailer:
     backup_ready:
-      explanation: Has solicitado una copia completa de tu cuenta de Mastodon. ¡Ya está preparada para descargar!
-      subject: Tu archivo está preparado para descargar
+      explanation: Ha solicitado una copia completa de su cuenta de Mastodon. ¡Ya está preparada para descargar!
+      subject: Su archivo está preparado para descargar
       title: Descargar archivo
+    warning:
+      explanation:
+        disable: Mientras su cuenta esta congelada sus datos quedan intactos, pero no puede hacer nada hasta que sea desbloqueada.
+        silence: Mientras su cuenta esté limitada, solo gente que ya le este siguiendo podran ver sus toots en este servidor, y puede que sea excluido de varias listados públicos. Sin embargo, otros pueden seguirle manualmente.
+        suspend: Su cuenta a sido suspendida, y todos sus toots y sus archivos de media subidos han sido irreversiblemente eliminado de este servidor, y de servidores donde tenía seguidores.
+      review_server_policies: Revisar políticas del servidor
+      subject:
+        disable: Su cuenta %{acct} a sido congelada
+        none: Advertencia para %{acct}
+        silence: Su cuenta %{acct} a sido limitada
+        suspend: Su cuenta %{acct} a sido suspendida
+      title:
+        disable: Cuenta congelada
+        none: Advertencia
+        silence: Cuenta limitada
+        suspend: Cuenta suspendida
     welcome:
       edit_profile_action: Configurar el perfil
-      edit_profile_step: Puedes personalizar tu perfil subiendo un avatar, una cabecera, cambiando tu nombre de usuario y más cosas. Si quieres revisar a tus nuevos seguidores antes de que se les permita seguirte, puedes bloquear tu cuenta.
+      edit_profile_step: Puedes personalizar tu perfil subiendo un avatar, una cabecera, cambiando su nombre de usuario y más. Si quiere revisar sus nuevos seguidores antes de que se les permita seguirte, puede bloquear su cuenta.
       explanation: Aquí hay algunos consejos para empezar
       final_action: Empezar a publicar
-      final_step: '¡Empieza a publicar! Incluso sin seguidores, tus mensajes públicos pueden ser vistos por otros, por ejemplo en la linea de tiempo local y con "hashtags". Podrías querer introducirte con el "hashtag" #introductions.'
+      final_step: '¡Empieza a publicar! Incluso sin seguidores, sus mensajes públicos pueden ser vistos por otros, por ejemplo en la cronología local y con etiquetas. Podría introducirse con la etiqueta #introductions.'
       full_handle: Su sobrenombre completo
-      full_handle_hint: Esto es lo que le dirías a tus amigos para que ellos puedan enviarte mensajes o seguirte desde otra instancia.
+      full_handle_hint: Esto es lo que le dirías a tus amigos para que ellos puedan enviarle mensajes o seguirle desde otra instancia.
       review_preferences_action: Cambiar preferencias
-      review_preferences_step: Asegúrate de poner tus preferencias, como que correos te gustaría recibir, o que nivel de privacidad te gustaría que tus publicaciones tengan por defecto. Si no tienes mareos, podrías elegir habilitar la reproducción automática de "GIFs".
+      review_preferences_step: Asegúrate de poner tus preferencias, como que correos te gustaría recibir, o que nivel de privacidad te gustaría que tus publicaciones tengan por defecto. Si no tiene cinetosis, podría activar la reproducción automática de GIFs.
       subject: Bienvenido a Mastodon
-      tip_federated_timeline: La línea de tiempo federada es una vista de la red de Mastodon. Pero solo incluye gente que tus vecinos están siguiendo, así que no está completa.
-      tip_following: Sigues a tus administradores de servidor por defecto. Para encontrar más gente interesante, revisa las lineas de tiempo local y federada.
-      tip_local_timeline: La linea de tiempo local is una vista de la gente en %{instance}. Estos son tus vecinos inmediatos!
+      tip_federated_timeline: La cronología federada es una vista de la red de Mastodon. Pero solo incluye gente que tus vecinos están siguiendo, así que no está completa.
+      tip_following: Sigues a tus administradores de servidor por defecto. Para encontrar más gente interesante, revisa las cronologías locales y federadas.
+      tip_local_timeline: La cronología local es una vista de la gente en %{instance}. Estos son tus vecinos inmediatos!
       tip_mobile_webapp: Si el navegador de tu dispositivo móvil ofrece agregar Mastodon a tu página de inicio, puedes recibir notificaciones. Actúa como una aplicación nativa en muchas formas!
-      tips: Tips
-      title: Te damos la bienvenida a bordo, %{name}!
+      tips: Consejos
+      title: ¡Te damos la bienvenida a bordo, %{name}!
   users:
     follow_limit_reached: No puedes seguir a más de %{limit} personas
     invalid_email: La dirección de correo es incorrecta
@@ -798,5 +999,5 @@ es:
     seamless_external_login: Has iniciado sesión desde un servicio externo, así que los ajustes de contraseña y correo no están disponibles.
     signed_in_as: 'Sesión iniciada como:'
   verification:
-    explanation_html: 'Puedes <strong> verificarte a ti mismo como el dueño de los links en los metadatos de tu perfil </strong>. Para eso, el sitio vinculado debe contener un vínculo a tu perfil de Mastodon. El vínculo en tu sitio <strong> debe </strong> tener un atributo <code> rel="me"</code>. El texto del vínculo no importa. Aquí un ejemplo:'
+    explanation_html: 'Puedes <strong>verificarte a ti mismo como el dueño de los links en los metadatos de tu perfil</strong>. Para eso, el sitio vinculado debe contener un vínculo a tu perfil de Mastodon. El vínculo en tu sitio <strong>debe</strong> tener un atributo <code>rel="me"</code>. El texto del vínculo no importa. Aquí hay un ejemplo:'
     verification: Verificación


### PR DESCRIPTION
The missing fields in the Spanish translation are almost completely filled. The only one I didn't include was `terms.body_html` because it seemed like something that should be a separate page that the admin can edit?

Anyways, I used formal language and changed some terms to match a closer Spanish equivalent. There might still be some parts that could be changed, but I'm stopping here so I don't become overwhelmed.

I also took the time to make some minor changes in the English file as recommended by #70.