### PR TITLE
Update French/English strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -406,11 +406,11 @@ en:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image
       max_bio_chars:
-        desc_html: 'Set maximum biography length in characters (default: 500)'
-        title: Max Biography Size
+        desc_html: 'Maximum biography length in characters (default: 500)'
+        title: Max biography size
       max_toot_chars:
-        desc_html: 'Set maximum toot length in characters (default: 500)'
-        title: Max Toot Size
+        desc_html: 'Maximum toot length in characters (default: 500)'
+        title: Max toot size
       peers_api_enabled:
         desc_html: Domain names this server has encountered in the fediverse
         title: Publish list of discovered servers

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -405,6 +405,12 @@ fr:
       mascot:
         desc_html: Affiché sur plusieurs pages. Au moins 293×205px recommandé. Lorsqu’il n’est pas défini, retombe à la mascotte par défaut
         title: Image de la mascotte
+      max_bio_chars:
+        desc_html: 'Définir la taille maximum de biographies en charactères (défaut : 500)'
+        title: Taille Maximum de Biographies
+      max_toot_chars:
+        desc_html: 'Définir la taille maximum de pouets en charactères (défaut : 500)'
+        title: Taille Maximum de Pouets
       peers_api_enabled:
         desc_html: Noms des domaines que ce serveur a découvert dans le fediverse
         title: Publier la liste des serveurs découverts

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -406,11 +406,11 @@ fr:
         desc_html: Affiché sur plusieurs pages. Au moins 293×205px recommandé. Lorsqu’il n’est pas défini, retombe à la mascotte par défaut
         title: Image de la mascotte
       max_bio_chars:
-        desc_html: 'Définir la taille maximum de biographies en charactères (défaut : 500)'
-        title: Taille Maximum de Biographies
+        desc_html: Longeur maximale des biographies en nombre de charactères (500 par défaut)
+        title: Longeur maximale des biographies
       max_toot_chars:
-        desc_html: 'Définir la taille maximum de pouets en charactères (défaut : 500)'
-        title: Taille Maximum de Pouets
+        desc_html: Longeur maximale des pouets en nombre de charactères (500 par défaut)
+        title: Longeur maximale des pouets
       peers_api_enabled:
         desc_html: Noms des domaines que ce serveur a découvert dans le fediverse
         title: Publier la liste des serveurs découverts

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -103,6 +103,7 @@ fr:
         setting_display_media_show_all: Montrer tout
         setting_expand_spoilers: Toujours développer les pouets marqués d’un avertissement de contenu
         setting_hide_network: Cacher votre réseau
+        setting_home_dms: Montrer les messages directs sur le fil d'accueil
         setting_noindex: Demander aux moteurs de recherche de ne pas indexer vos informations personnelles
         setting_reduce_motion: Réduire la vitesse des animations
         setting_show_application: Dévoiler le nom de l’application utilisée pour envoyer des pouets


### PR DESCRIPTION
Adds strings for the new stuff in pre-release 0.1.0 for French, and slightly modifies the English strings to be more natural; the setting is in sentence case instead of title case, and the "Set the" has been dropped.