### PR TITLE
Offer Mastodon::Version::Equiv, report this in API

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -28,6 +28,14 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   end
 
   def version
+    Mastodon::Version::Equiv.to_s
+  end
+
+  def flavor_name
+    Mastodon::Version.flavor
+  end
+
+  def flavor_version
     Mastodon::Version.to_s
   end
 

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -4,6 +4,63 @@ module Mastodon
   module Version
     module_function
 
+    # equivalent mastodon version
+    module Equiv
+      module_function
+
+      def major
+        2
+      end
+
+      def minor
+        9
+      end
+
+      def patch
+        0
+      end
+
+      def pre
+        nil
+      end
+
+      def flags
+        ''
+      end
+
+      def to_a
+        [major, minor, patch, pre].compact
+      end
+
+      def suffix
+        ['+', Version.flavor].join
+      end
+
+      def to_s
+        [to_a.join('.'), flags, suffix].join
+      end
+
+      def repository
+        Version.repository
+      end
+
+      def source_base_url
+        Version.source_base_url
+      end
+
+      def source_tag
+        Version.source_tag
+      end
+
+      def source_url
+        Version.source_url
+      end
+
+      def user_agent
+        @user_agent ||= "#{HTTP::Request::USER_AGENT} (Mastodon/#{Equiv}; +http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/)"
+      end
+    end
+
     def compat
       0
     end
@@ -22,6 +79,10 @@ module Mastodon
 
     def suffix
         ''
+    end
+
+    def flavor
+      'florence'
     end
 
     def to_a


### PR DESCRIPTION
Not yet tested, but essentially, this would add two additional fields to the API: `flavor_name`, which we'll set to `florence`, and `flavor_version`, which will be set to the actual version of Florence Mastodon. We should double-check with Pleroma and glitch-social before merging to co-ordinate with them and figure out if they're doing this through their own APIs, and/or if we want to make this official for app developers to take advantage of.

The `Mastodon::Version::Equiv` object will contain an object closer to the actual Mastodon version, while the actual `Mastodon::Version` object will contain the Florence Mastodon version.

This is a *giant mess*, but it solves the problem right now. Eventually, we'll want to extract all of the actual version information out of this file, and leave only Mastodon-equivalent stuff for the API here.