### PR TITLE
Fix incorrect merge of admin settings

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -11,6 +11,8 @@ class Form::AdminSettings
     site_description
     site_extended_description
     site_terms
+    max_bio_chars
+    max_toot_chars
     registrations_mode
     closed_registrations_message
     open_deletion


### PR DESCRIPTION
Fixes #101. This was due to these keys being left out when merging upstream changes.