### PR TITLE
Set firewall to IP-block Gab's instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,15 @@ RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	ip6tables -I INPUT -s 2606:4700::6810:7960 -j DROP && \
 	ip6tables -I OUTPUT -d 2606:4700::6810:7a60 -j REJECT && \
 	ip6tables -I OUTPUT -d 2606:4700::6810:7960 -j REJECT
+# block gab.ai
+RUN iptables -I INPUT -s 104.18.8.237 -j DROP && \
+	iptables -I INPUT -s 104.18.9.237 -j DROP && \
+	iptables -I OUTPUT -d 104.18.8.237 -j REJECT && \
+	iptables -I OUTPUT -d 104.18.9.237 -j REJECT && \
+	ip6tables -I INPUT -s 2606:4700::6812:8ed -j DROP && \
+	ip6tables -I INPUT -s 2606:4700::6812:9ed -j DROP && \
+	ip6tables -I OUTPUT -d 2606:4700::6812:8ed -j REJECT && \
+	ip6tables -I OUTPUT -d 2606:4700::6812:9ed -j REJECT
 
 # Set the run user
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,10 +114,10 @@ ENV NODE_ENV="production"
 ENV RAILS_SERVE_STATIC_FILES="true"
 
 # Configure firewall
-# block gab.com
+# block develop.gab.com (previous IP)
 RUN iptables -I INPUT -s 165.22.0.19 -j DROP && \
 	iptables -I OUTPUT -d 165.22.0.19 -j REJECT
-# block develop.gab.com
+# block gab.com
 RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	iptables -I INPUT -s 104.16.122.96 -j DROP && \
 	iptables -I OUTPUT -d 104.16.121.96 -j REJECT && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,9 @@ ENV NODE_ENV="production"
 ENV RAILS_SERVE_STATIC_FILES="true"
 
 # Configure firewall
-RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
+RUN iptables -I INPUT -s 165.22.0.19 -j DROP && \
+	iptables -I INPUT -d 165.22.0.19 -j REJECT && \
+	iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	iptables -I INPUT -s 104.16.122.96 -j DROP && \
 	iptables -I INPUT -d 104.16.121.96 -j REJECT && \
 	iptables -I INPUT -d 104.16.122.96 -j REJECT && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,12 @@ ENV NODE_ENV="production"
 # Tell rails to serve static files
 ENV RAILS_SERVE_STATIC_FILES="true"
 
+# Configure firewall
+RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
+	iptables -I INPUT -s 104.16.122.96 -j DROP && \
+	iptables -I INPUT -d 104.16.121.96 -j REJECT && \
+	iptables -I INPUT -d 104.16.122.96 -j REJECT
+
 # Set the run user
 USER mastodon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,15 +115,15 @@ ENV RAILS_SERVE_STATIC_FILES="true"
 
 # Configure firewall
 RUN iptables -I INPUT -s 165.22.0.19 -j DROP && \
-	iptables -I INPUT -d 165.22.0.19 -j REJECT && \
+	iptables -I OUTPUT -d 165.22.0.19 -j REJECT && \
 	iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	iptables -I INPUT -s 104.16.122.96 -j DROP && \
-	iptables -I INPUT -d 104.16.121.96 -j REJECT && \
-	iptables -I INPUT -d 104.16.122.96 -j REJECT && \
+	iptables -I OUTPUT -d 104.16.121.96 -j REJECT && \
+	iptables -I OUTPUT -d 104.16.122.96 -j REJECT && \
 	ip6tables -I INPUT -s 2606:4700::6810:7a60 -j DROP && \
 	ip6tables -I INPUT -s 2606:4700::6810:7960 -j DROP && \
-	ip6tables -I INPUT -d 2606:4700::6810:7a60 -j REJECT && \
-	ip6tables -I INPUT -d 2606:4700::6810:7960 -j REJECT
+	ip6tables -I OUTPUT -d 2606:4700::6810:7a60 -j REJECT && \
+	ip6tables -I OUTPUT -d 2606:4700::6810:7960 -j REJECT
 
 # Set the run user
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,11 @@ ENV RAILS_SERVE_STATIC_FILES="true"
 RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	iptables -I INPUT -s 104.16.122.96 -j DROP && \
 	iptables -I INPUT -d 104.16.121.96 -j REJECT && \
-	iptables -I INPUT -d 104.16.122.96 -j REJECT
+	iptables -I INPUT -d 104.16.122.96 -j REJECT && \
+	ip6tables -I INPUT -s 2606:4700::6810:7a60 -j DROP && \
+	ip6tables -I INPUT -s 2606:4700::6810:7960 -j DROP && \
+	ip6tables -I INPUT -d 2606:4700::6810:7a60 -j REJECT && \
+	ip6tables -I INPUT -d 2606:4700::6810:7960 -j REJECT
 
 # Set the run user
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,9 +114,11 @@ ENV NODE_ENV="production"
 ENV RAILS_SERVE_STATIC_FILES="true"
 
 # Configure firewall
+# block gab.com
 RUN iptables -I INPUT -s 165.22.0.19 -j DROP && \
-	iptables -I OUTPUT -d 165.22.0.19 -j REJECT && \
-	iptables -I INPUT -s 104.16.121.96 -j DROP && \
+	iptables -I OUTPUT -d 165.22.0.19 -j REJECT
+# block develop.gab.com
+RUN iptables -I INPUT -s 104.16.121.96 -j DROP && \
 	iptables -I INPUT -s 104.16.122.96 -j DROP && \
 	iptables -I OUTPUT -d 104.16.121.96 -j REJECT && \
 	iptables -I OUTPUT -d 104.16.122.96 -j REJECT && \


### PR DESCRIPTION
This pull request should set up the Docker image so that it doesn't accept any packets either to or from `gab.com` or `develop.gab.com`. This (partly) fixes #120.

**Important note**: I say "should" because this has not been tested on the image itself yet. Local tests work, but the behavior on the image has yet to be verified. Also, this pull request should remain open until the IP of the official instance is announced so it can be included if needed.