### PR TITLE
Add version suffix for Florence

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -21,7 +21,7 @@ module Mastodon
     end
 
     def suffix
-        ''
+      '+florence'
     end
 
     def to_a
@@ -29,7 +29,7 @@ module Mastodon
     end
 
     def to_s
-      to_a.push(suffix).join('.')
+      to_a.join('.') + suffix
     end
 
     def repository

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -4,32 +4,36 @@ module Mastodon
   module Version
     module_function
 
-    def compat
+    def major
+      2
+    end
+
+    def minor
+      9
+    end
+
+    def patch
       0
     end
 
-    def feel
-      0
+    def pre
+      nil
     end
 
-    def feature
-      1
+    def flags
+      ''
     end
 
-    def hotfix
-      0
+    def to_a
+      [major, minor, patch, pre].compact
     end
 
     def suffix
       '+florence'
     end
 
-    def to_a
-      [compat, feel, feature, hotfix]
-    end
-
     def to_s
-      to_a.join('.') + suffix
+      [to_a.join('.'), flags, suffix].join
     end
 
     def repository


### PR DESCRIPTION
This adds `+florence` to the version string, and fixes a minor issue where there was an extra dot after the version due to improper formatting.

Fixes #99. Further discussion is still needed at #136 for how to communicate Florence version information.