### PR TITLE
Added max_toot_chars and max_bio_chars to /api/v1/instance

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -5,7 +5,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   attributes :uri, :title, :description, :email,
              :version, :urls, :stats, :thumbnail,
-             :languages, :registrations
+             :languages, :registrations,
+             :max_toot_chars, :max_bio_chars
 
   has_one :contact_account, serializer: REST::AccountSerializer
 
@@ -33,6 +34,14 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def thumbnail
     instance_presenter.thumbnail ? full_asset_url(instance_presenter.thumbnail.file.url) : full_pack_url('media/images/preview.jpg')
+  end
+
+  def max_toot_chars
+    Setting.max_toot_chars
+  end
+
+  def max_bio_chars
+    Setting.max_bio_chars
   end
 
   def stats


### PR DESCRIPTION
This adds the maximum number of characters for toots and the maximum number of characters for the bio field to `/api/v1/instance/`.

This fixes #128.