### PR TITLE
Remove 'filtered' tombstones from timeline view

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -288,18 +288,7 @@ class Status extends ImmutablePureComponent {
     }
 
     if (status.get('filtered') || status.getIn(['reblog', 'filtered'])) {
-      const minHandlers = this.props.muted ? {} : {
-        moveUp: this.handleHotkeyMoveUp,
-        moveDown: this.handleHotkeyMoveDown,
-      };
-
-      return (
-        <HotKeys handlers={minHandlers}>
-          <div className='status__wrapper status__wrapper--filtered focusable' tabIndex='0' ref={this.handleRef}>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />
-          </div>
-        </HotKeys>
-      );
+      return (null);
     }
 
     if (featured) {


### PR DESCRIPTION
Going to need to actually test this to see if this works. But, otherwise, this should just outright remove the tombstones from the timeline view.

Fixes #28.