### PR TITLE
Add Florence::Version

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -17,6 +17,7 @@ module Admin
       @invites_enabled       = Setting.min_invite_role == 'user'
       @search_enabled        = Chewy.enabled?
       @version               = Florence::Version.to_s
+      @masto_version         = Mastodon::Version.to_s
       @database_version      = ActiveRecord::Base.connection.execute('SELECT VERSION()').first['version'].match(/\A(?:PostgreSQL |)([^\s]+).*\z/)[1]
       @redis_version         = redis_info['redis_version']
       @reports_count         = Report.unresolved.count

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -16,7 +16,7 @@ module Admin
       @deletions_enabled     = Setting.open_deletion
       @invites_enabled       = Setting.min_invite_role == 'user'
       @search_enabled        = Chewy.enabled?
-      @version               = Mastodon::Version.to_s
+      @version               = Florence::Version.to_s
       @database_version      = ActiveRecord::Base.connection.execute('SELECT VERSION()').first['version'].match(/\A(?:PostgreSQL |)([^\s]+).*\z/)[1]
       @redis_version         = redis_info['redis_version']
       @reports_count         = Report.unresolved.count

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -39,7 +39,7 @@ class InstancePresenter
   end
 
   def version_number
-    Mastodon::Version
+    Florence::Version
   end
 
   def source_url

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -16,7 +16,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       search_enabled: Chewy.enabled?,
       repository: Mastodon::Version.repository,
       source_url: Mastodon::Version.source_url,
-      version: Mastodon::Version.to_s,
+      version: Florence::Version.to_s,
       invites_enabled: Setting.min_invite_role == 'user',
       mascot: instance_presenter.mascot&.file&.url,
       profile_directory: Setting.profile_directory,

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -59,7 +59,10 @@
         %li
           Florence-Mastodon
           %span.pull-right= @version
-        %li
+         %li
+           Mastodon
+           %span.pull-right= @masto_version
+         %li
           Ruby
           %span.pull-right= "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
         %li

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -59,10 +59,10 @@
         %li
           Florence-Mastodon
           %span.pull-right= @version
-         %li
+        %li
            Mastodon
            %span.pull-right= @masto_version
-         %li
+        %li
           Ruby
           %span.pull-right= "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
         %li

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -57,7 +57,7 @@
       %h4= t 'admin.dashboard.software'
       %ul
         %li
-          Florence-Mastodon
+          Florence
           %span.pull-right= @version
         %li
            Mastodon

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -57,7 +57,7 @@
       %h4= t 'admin.dashboard.software'
       %ul
         %li
-          Mastodon
+          Florence-Mastodon
           %span.pull-right= @version
         %li
           Ruby

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -43,7 +43,7 @@
             %h4= site_hostname
             %ul
               %li= link_to t('about.about_this'), about_more_path
-              %li= "v#{Mastodon::Version.to_s}"
+              %li= "v#{Florence::Version.to_s}"
           .column-4
             %h4= t 'footer.more'
             %ul

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ require_relative '../lib/paperclip/gif_transcoder'
 require_relative '../lib/paperclip/video_transcoder'
 require_relative '../lib/mastodon/snowflake'
 require_relative '../lib/mastodon/version'
+require_relative '../lib/florence/version'
 require_relative '../lib/devise/ldap_authenticatable'
 
 Dotenv::Railtie.load

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -122,7 +122,7 @@ module Mastodon
 
     desc 'version', 'Show version'
     def version
-      say(Mastodon::Version.to_s)
+      say("#{Florence::Version} (equiv: Mastodon #{Mastodon::Version})")
     end
   end
 end

--- a/lib/florence/version.rb
+++ b/lib/florence/version.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Florence
+  module Version
+    module_function
+
+    def compatibility
+      0
+    end
+
+    def feel
+      0
+    end
+
+    def feature
+      1
+    end
+
+    def hotfix
+      1
+    end
+
+    def suffix
+      ''
+    end
+
+    def to_a
+      [compatibility, feel, feature, hotfix]
+    end
+
+    def to_s
+      [to_a.join('.'), suffix].join
+    end
+  end
+end
+

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -85,8 +85,8 @@ describe InstancePresenter do
   end
 
   describe '#version_number' do
-    it 'returns Mastodon::Version' do
-      expect(instance_presenter.version_number).to be(Mastodon::Version)
+    it 'returns Florence::Version' do
+      expect(instance_presenter.version_number).to be(Florence::Version)
     end
   end
 


### PR DESCRIPTION
This adds a separate `Florence::Version` module which is separate from the Mastodon version, and will be displayed to the user.