### PR TITLE
Fix type for max_toot_chars and max_bio_chars in instance info

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -42,6 +42,11 @@ module Admin
       preview_sensitive_media
       profile_directory
     ).freeze
+  
+    INTEGER_SETTINGS = %w(
+      max_bio_chars
+      max_toot_chars
+    ).freeze
 
     UPLOAD_SETTINGS = %w(
       thumbnail

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -96,13 +96,8 @@ class Form::AdminSettings
   def typecast_value(key, value)
     if BOOLEAN_KEYS.include?(key)
       value == '1'
-    # FIXME: `i18n-tasks unused -l en` doesn't seem to like this. Fails with:
-    #   i18n-tasks: Error scanning app/models/form/admin_settings.rb: undefined
-    #   method `to_ast' for false:FalseClass
-    #   Did you mean?  to_s
-    #
-    #else if INTEGER_KEYS.include?(key)
-    #  value.to_i
+    elsif INTEGER_KEYS.include?(key)
+      value.to_i
     else
       value
     end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -96,8 +96,13 @@ class Form::AdminSettings
   def typecast_value(key, value)
     if BOOLEAN_KEYS.include?(key)
       value == '1'
-    else if INTEGER_KEYS.include?(key)
-      value.to_i
+    # FIXME: `i18n-tasks unused -l en` doesn't seem to like this. Fails with:
+    #   i18n-tasks: Error scanning app/models/form/admin_settings.rb: undefined
+    #   method `to_ast' for false:FalseClass
+    #   Did you mean?  to_s
+    #
+    #else if INTEGER_KEYS.include?(key)
+    #  value.to_i
     else
       value
     end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -42,6 +42,11 @@ class Form::AdminSettings
     preview_sensitive_media
     profile_directory
   ).freeze
+  
+  INTEGER_KEYS = %i(
+    max_bio_chars
+    max_toot_chars
+  ).freeze
 
   UPLOAD_KEYS = %i(
     thumbnail
@@ -91,6 +96,8 @@ class Form::AdminSettings
   def typecast_value(key, value)
     if BOOLEAN_KEYS.include?(key)
       value == '1'
+    else if INTEGER_KEYS.include?(key)
+      value.to_i
     else
       value
     end

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -37,11 +37,11 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   end
 
   def max_toot_chars
-    Setting.max_toot_chars
+    Setting.max_toot_chars.to_i
   end
 
   def max_bio_chars
-    Setting.max_bio_chars
+    Setting.max_bio_chars.to_i
   end
 
   def stats


### PR DESCRIPTION
This should fix #161.

Also took the time to treat them as integers in the admin settings. Hopefully that will be useful in the future.