### PR TITLE
Fix inconsistent indentation in admin dashboard causing 500.

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -60,8 +60,8 @@
           Florence
           %span.pull-right= @version
         %li
-           Mastodon
-           %span.pull-right= @masto_version
+          Mastodon
+          %span.pull-right= @masto_version
         %li
           Ruby
           %span.pull-right= "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"


### PR DESCRIPTION
I have bookmarks that I have been using to work around this and get to subpages, now I have some time to look at logs as follows

```
Nov 14 19:23:39 mastodon-holomaplefeline heroku/router:  at=info method=GET path="/admin/dashboard" host=social.holomaplefeline.net request_id=ab130971-c16a-4e59-98d2-6cb9b8e30319 fwd="172.58.43.43" dyno=web.1 connect=1ms service=54ms status=500 bytes=1037 protocol=https
Nov 14 19:23:39 mastodon-holomaplefeline app/web.1:  [ab130971-c16a-4e59-98d2-6cb9b8e30319] method=GET path=/admin/dashboard format=html controller=Admin::DashboardController action=index status=500 error='ActionView::Template::Error: Inconsistent indentation: 11 spaces used for indentation, but the rest of the document was indented using 2 spaces.' duration=49.79 view=0.00 db=15.57
```