### PR TITLE
Fix indentation issue causing a 500 error on admin dashboard

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -60,8 +60,8 @@
           Florence
           %span.pull-right= @version
         %li
-           Mastodon
-           %span.pull-right= @masto_version
+          Mastodon
+          %span.pull-right= @masto_version
         %li
           Ruby
           %span.pull-right= "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"


### PR DESCRIPTION
It crashes if indentation is not a multiple of 2.