### PR TITLE
Quarantine new instances by default.

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -26,7 +26,6 @@ module Admin
           @domain_block.update(resource_params)
         end
         if @domain_block.save
-          DomainBlockWorker.perform_async(@domain_block.id)
           log_action :create, @domain_block
           redirect_to admin_instances_path(limited: '1'), notice: I18n.t('admin.domain_blocks.created_msg')
         else

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -39,4 +39,12 @@ class DomainBlock < ApplicationRecord
     scope = suspend? ? accounts.where(suspended_at: created_at) : accounts.where(silenced_at: created_at)
     scope.count
   end
+
+  after_save :process_domain_block
+
+  private
+
+  def process_domain_block
+    DomainBlockWorker.perform_in(2.minutes, id)
+  end
 end

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ReportWorker
+  include Sidekiq::Worker
+
+  def perform(source_account_id, target_account_username, target_account_domain, options = {})
+    ReportService.new.call(
+      Account.find(source_account_id),
+      Account.find_by(domain: target_account_domain, username: target_account_username),
+      options
+    )
+  end
+end


### PR DESCRIPTION
I cleaned up https://github.com/maplefeline/mastodon-fork/tree/citizenship.
I'm not sure this is enough to close #113 but I'm a bit stuck at the moment. Mapping an administration flag to disable this is lost to me, and without the flag approaching the tests is challenging.
Given I have seen my instance get hit with 50 new domains in an hour I'm going to continue running this patch on https://social.holomaplefeline.net